### PR TITLE
Post release 0.8.0: Update version to 0.8.0.dev0

### DIFF
--- a/.github/workflows/daily_scan.yml
+++ b/.github/workflows/daily_scan.yml
@@ -82,7 +82,7 @@ jobs:
         id: high_scan
         uses: ./.github/actions/image_scan
         with:
-          image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.7.0"
+          image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.8.0"
           severity: 'CRITICAL,HIGH'
 
       - name: Perform low image scan
@@ -90,7 +90,7 @@ jobs:
         id: low_scan
         uses: ./.github/actions/image_scan
         with:
-          image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.7.0"
+          image-ref: "public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.8.0"
           severity: 'MEDIUM,LOW,UNKNOWN'
 
       - name: Configure AWS Credentials for emitting metrics

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -118,3 +118,27 @@ jobs:
           By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice." \
                        --head prepare-main-for-next-dev-cycle-${VERSION} \
                        --base main
+
+                       https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.32.5/aws-opentelemetry-agent.jar
+
+        - name: Get SHA256 checksum of wheel file
+        id: get_sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          checksum=$(shasum -a 256 dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl | awk '{ print $1 }')
+          echo "CHECKSUM=$checksum" >> $GITHUB_OUTPUT
+
+      - name: Append checksum and update version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl ${{ steps.get_sha256.outputs.CHECKSUM }}" >> checksum.txt
+          echo "${{ github.event.inputs.version }}" > version.txt
+
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Action Release Workflow"
+          git add checksum.txt version.txt
+          git commit -m "Update latest version and append checksum"
+          git push
+

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -5,7 +5,9 @@ on:
     inputs:
       version:
         description: 'Version number (e.g., 1.0.1)'
-        required: true
+        required: false
+        default: "0.7.0"
+  push:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -53,7 +55,6 @@ jobs:
             exit 1
           fi
   
-
   prepare-main:
     runs-on: ubuntu-latest
     needs: check-version
@@ -102,6 +103,24 @@ jobs:
           sed -i 's/python:v.*"/python:v'$VERSION'"/' .github/workflows/daily_scan.yml
           git add aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
           git add .github/workflows/daily_scan.yml
+
+      - name: Get the checksum of the latest release and append to metafile.json
+        run: |
+          ARTIFACT_NAME="aws_opentelemetry_distro-${{ env.VERSION }}-py3-none-any.whl"
+          curl -L -o $ARTIFACT_NAME https://github.com/aws-observability/aws-otel-python-instrumentation/releases/download/${{ env.VERSION }}/$ARTIFACT_NAME
+
+          CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')
+
+          FILE="release-build-metadata.json"
+          UPDATED_JSON=$(jq --arg version "${{ env.VERSION }}" \
+                            --arg name "$ARTIFACT_NAME" \
+                            --arg checksum "$CHECKSUM" \
+                            '.release += [{"version": $version, "checksum": [{"name": $name, "checksum": $checksum}]}]' "$FILE")
+
+          echo "$UPDATED_JSON" > "$FILE"
+
+      - name: Push changes to Github
+        run: |
           git commit -m "Prepare main for next development cycle: Update version to $DEV_VERSION"
           git push --set-upstream origin "prepare-main-for-next-dev-cycle-${VERSION}"
 
@@ -121,7 +140,7 @@ jobs:
 
                        https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.32.5/aws-opentelemetry-agent.jar
 
-        - name: Get SHA256 checksum of wheel file
+      - name: Get SHA256 checksum of wheel file
         id: get_sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Extract Major.Minor Version and setup Env variable
         run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
+          echo "VERSION=0.7.0" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo 0.7.0 | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+/\1/')" >> $GITHUB_ENV
 
       - name: Determine release branch and checkout
         run: |
@@ -105,19 +105,17 @@ jobs:
           git add aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
           git add .github/workflows/daily_scan.yml
   
-      - name: Get the checksum of the latest release and append to metafile.json
+      - name: Append latest release checksum to release-build-metadata.json
         run: |
-          echo "ARTIFACT_NAME='aws_opentelemetry_distro-${{ env.VERSION }}-py3-none-any.whl'" >> $GITHUB_ENV
+          ARTIFACT_NAME="aws_opentelemetry_distro-${{ env.VERSION }}-py3-none-any.whl"
           curl -L -o $ARTIFACT_NAME https://github.com/aws-observability/aws-otel-python-instrumentation/releases/download/v${{ env.VERSION }}/$ARTIFACT_NAME
 
-          echo "CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')"" >> $GITHUB_ENV
+          CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')
 
-      - name: Append checksum to metafile
-        run: |
           FILE="release-build-metadata.json"
           UPDATED_JSON=$(jq --arg version "${{ env.VERSION }}" \
-                            --arg name "${{ env.ARTIFACT_NAME }}" \
-                            --arg checksum "${{ env.CHECKSUM }}" \
+                            --arg name "$ARTIFACT_NAME" \
+                            --arg checksum "$CHECKSUM" \
                             '.release += [{"version": $version, "checksum": [{"name": $name, "checksum": $checksum}]}]' "$FILE")
 
           echo "$UPDATED_JSON" > "$FILE"

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
+          ref: add-checksum
 
       - name: Configure Git
         run: |
@@ -97,27 +98,30 @@ jobs:
 
       - name: Update version to next development version in main
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}.dev0"
+          DEV_VERSION="0.7.0.dev0"
           sed -i 's/__version__ = ".*"/__version__ = "'$DEV_VERSION'"/' aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="0.7.0"
           sed -i 's/python:v.*"/python:v'$VERSION'"/' .github/workflows/daily_scan.yml
           git add aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
           git add .github/workflows/daily_scan.yml
-
+  
       - name: Get the checksum of the latest release and append to metafile.json
         run: |
-          ARTIFACT_NAME="aws_opentelemetry_distro-${{ env.VERSION }}-py3-none-any.whl"
-          curl -L -o $ARTIFACT_NAME https://github.com/aws-observability/aws-otel-python-instrumentation/releases/download/${{ env.VERSION }}/$ARTIFACT_NAME
+          echo "ARTIFACT_NAME='aws_opentelemetry_distro-${{ env.VERSION }}-py3-none-any.whl'" >> $GITHUB_ENV
+          curl -L -o $ARTIFACT_NAME https://github.com/aws-observability/aws-otel-python-instrumentation/releases/download/v${{ env.VERSION }}/$ARTIFACT_NAME
 
-          CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')
+          echo "CHECKSUM=$(shasum -a 256 $ARTIFACT_NAME | awk '{ print $1 }')"" >> $GITHUB_ENV
 
+      - name: Append checksum to metafile
+        run: |
           FILE="release-build-metadata.json"
           UPDATED_JSON=$(jq --arg version "${{ env.VERSION }}" \
-                            --arg name "$ARTIFACT_NAME" \
-                            --arg checksum "$CHECKSUM" \
+                            --arg name "${{ env.ARTIFACT_NAME }}" \
+                            --arg checksum "${{ env.CHECKSUM }}" \
                             '.release += [{"version": $version, "checksum": [{"name": $name, "checksum": $checksum}]}]' "$FILE")
 
           echo "$UPDATED_JSON" > "$FILE"
+          git add release-build-metadata.json
 
       - name: Push changes to Github
         run: |
@@ -128,36 +132,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
         run: |
-          DEV_VERSION="${{ github.event.inputs.version }}.dev0"
+          DEV_VERSION="0.7.0.dev0"
           gh pr create --title "Post release $VERSION: Update version to $DEV_VERSION" \
-                       --body "This PR prepares the main branch for the next development cycle by updating the version to $DEV_VERSION and updating the image version to be scanned to the latest released.
+                        --body "This PR prepares the main branch for the next development cycle by updating the version to $DEV_VERSION and updating the image version to be scanned to the latest released.
           
           This PR should only be merge when release for version v$VERSION is success.
           
           By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice." \
-                       --head prepare-main-for-next-dev-cycle-${VERSION} \
-                       --base main
-
-                       https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.32.5/aws-opentelemetry-agent.jar
-
-      - name: Get SHA256 checksum of wheel file
-        id: get_sha256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          checksum=$(shasum -a 256 dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl | awk '{ print $1 }')
-          echo "CHECKSUM=$checksum" >> $GITHUB_OUTPUT
-
-      - name: Append checksum and update version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl ${{ steps.get_sha256.outputs.CHECKSUM }}" >> checksum.txt
-          echo "${{ github.event.inputs.version }}" > version.txt
-
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "GitHub Action Release Workflow"
-          git add checksum.txt version.txt
-          git commit -m "Update latest version and append checksum"
-          git push
-
+                        --head prepare-main-for-next-dev-cycle-${VERSION} \
+                        --base main
+  

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -131,28 +131,6 @@ jobs:
              --draft \
              "v${{ github.event.inputs.version }}" \
              dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
-
-      - name: Get SHA256 checksum of wheel file
-        id: get_sha256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          checksum=$(shasum -a 256 dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl | awk '{ print $1 }')
-          echo "CHECKSUM=$checksum" >> $GITHUB_OUTPUT
-
-      - name: Append checksum and update version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl ${{ steps.get_sha256.outputs.CHECKSUM }}" >> checksum.txt
-          echo "${{ github.event.inputs.version }}" > version.txt
-
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "GitHub Action Release Workflow"
-          git add checksum.txt version.txt
-          git commit -m "Update latest version and append checksum"
-          git push
-
         
           
 

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -131,3 +131,28 @@ jobs:
              --draft \
              "v${{ github.event.inputs.version }}" \
              dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+
+      - name: Get SHA256 checksum of wheel file
+        id: get_sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          checksum=$(shasum -a 256 dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl | awk '{ print $1 }')
+          echo "CHECKSUM=$checksum" >> $GITHUB_OUTPUT
+
+      - name: Append checksum and update version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl ${{ steps.get_sha256.outputs.CHECKSUM }}" >> checksum.txt
+          echo "${{ github.event.inputs.version }}" > version.txt
+
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Action Release Workflow"
+          git add checksum.txt version.txt
+          git commit -m "Update latest version and append checksum"
+          git push
+
+        
+          
+

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.7.0.dev0"
+__version__ = "0.8.0.dev0"

--- a/release-build-metadata.json
+++ b/release-build-metadata.json
@@ -1,0 +1,14 @@
+{
+    "release": [
+        {
+            "version": "0.7.0",
+            "checksum": [
+                {
+                    "name": "aws_opentelemetry_distro-0.7.0-py3-none-any.whl",
+                    "checksum": "8cf682fa56bc00326a741acf480024550017beda41acb1b51af9d3b5ef1a9470"
+                }
+            ]
+        }
+    ]
+}
+  

--- a/release-build-metadata.json
+++ b/release-build-metadata.json
@@ -1,14 +1,22 @@
 {
-    "release": [
+  "release": [
+    {
+      "version": "0.7.0",
+      "checksum": [
         {
-            "version": "0.7.0",
-            "checksum": [
-                {
-                    "name": "aws_opentelemetry_distro-0.7.0-py3-none-any.whl",
-                    "checksum": "8cf682fa56bc00326a741acf480024550017beda41acb1b51af9d3b5ef1a9470"
-                }
-            ]
+          "name": "aws_opentelemetry_distro-0.7.0-py3-none-any.whl",
+          "checksum": "8cf682fa56bc00326a741acf480024550017beda41acb1b51af9d3b5ef1a9470"
         }
-    ]
+      ]
+    },
+    {
+      "version": "0.8.0",
+      "checksum": [
+        {
+          "name": "aws_opentelemetry_distro-0.7.0-py3-none-any.whl",
+          "checksum": "8cf682fa56bc00326a741acf480024550017beda41acb1b51af9d3b5ef1a9470"
+        }
+      ]
+    }
+  ]
 }
-  


### PR DESCRIPTION
This PR prepares the main branch for the next development cycle by updating the version to 0.8.0.dev0 and updating the image version to be scanned to the latest released.               --base add-checksum

This PR should only be merge when release for version v0.8.0 is success.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.